### PR TITLE
Updates and fixes to WebBridge Core

### DIFF
--- a/api/rest/overview.go
+++ b/api/rest/overview.go
@@ -195,7 +195,7 @@ func (w *WebBridgeRunner) GetBridgeOverview() (*models.BridgeOverview, int, erro
 // @Description Returns the current WebBridge overview status
 // @Accept  json
 // @Produce  json
-// @Success 200 {object} models.WalletSetupStatus "ok"
+// @Success 200 {object} models.OverviewResponse "ok"
 // @Failure 400 {object} string "Bad request"
 // @Failure 500 {object} string "Internal error"
 // @Router /api/v1/overview [get]

--- a/api/rest/router.go
+++ b/api/rest/router.go
@@ -67,12 +67,10 @@ func startGinGonic() {
 		Addr:    runner.configuration.WebServer().AddressPortString(),
 		Handler: runner.router,
 	}
-	go func() {
-		// Start HTTP service
-		if err := runner.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			panic(fmt.Errorf("ListenAndServe failed: %v", err))
-		}
-	}()
+	// Start HTTP service
+	if err := runner.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		panic(fmt.Errorf("ListenAndServe failed: %v", err))
+	}
 }
 
 // RestartWebServiceRouter running service is shutdown and a new service is ran with a new configuration

--- a/api/rest/shutdown.go
+++ b/api/rest/shutdown.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/duality-solutions/web-bridge/blockchain/rpc/dynamic"
 	"github.com/duality-solutions/web-bridge/bridge"
 	"github.com/duality-solutions/web-bridge/internal/util"
-	"github.com/duality-solutions/web-bridge/blockchain/rpc/dynamic"
 	"github.com/gin-gonic/gin"
 )
 
@@ -20,20 +20,18 @@ type AppShutdown struct {
 
 // ShutdownAppliction safely shuts down bridge proxies, process watcher, and the Dynamic daemon before exiting
 func (a *AppShutdown) ShutdownAppliction() {
-	go func() {
-		close(*a.StopWatcher)
-		bridge.ShutdownBridges(a.StopBridges)
-		// Stop dynamicd
-		reqStop, _ := dynamic.NewRequest("dynamic-cli stop")
-		respStop, _ := util.BeautifyJSON(<-a.Dynamicd.ExecCmdRequest(reqStop))
-		util.Info.Println(respStop)
-		time.Sleep(time.Second * 5)
-		util.Info.Println("Looking for dynamicd process pid", a.Dynamicd.Cmd.Process.Pid)
-		util.WaitForProcessShutdown(a.Dynamicd.Cmd.Process, time.Second*240)
-		util.Info.Println("Exit.")
-		util.EndDebugLogFile(30)
-		close(*a.Close)
-	}()
+	close(*a.StopWatcher)
+	bridge.ShutdownBridges(a.StopBridges)
+	// Stop dynamicd
+	reqStop, _ := dynamic.NewRequest("dynamic-cli stop")
+	respStop, _ := util.BeautifyJSON(<-a.Dynamicd.ExecCmdRequest(reqStop))
+	util.Info.Println(respStop)
+	time.Sleep(time.Second * 5)
+	util.Info.Println("Looking for dynamicd process pid", a.Dynamicd.Cmd.Process.Pid)
+	util.WaitForProcessShutdown(a.Dynamicd.Cmd.Process, time.Second*240)
+	util.Info.Println("Exit.")
+	util.EndDebugLogFile(30)
+	close(*a.Close)
 }
 
 func (w *WebBridgeRunner) shutdown(c *gin.Context) {

--- a/api/rest/walletsetup.go
+++ b/api/rest/walletsetup.go
@@ -36,7 +36,7 @@ func (w *WebBridgeRunner) GetWalletSetupInfo() (*models.WalletSetupStatus, int, 
 		strErrMsg := fmt.Sprintf("Results JSON unmarshal error %v", err)
 		return nil, http.StatusInternalServerError, errors.New(strErrMsg)
 	}
-	var currentStatus = w.configuration.WalletSetupStatus()
+	var currentStatus = *w.configuration.WalletSetupStatus()
 	status.MnemonicBackup = currentStatus.MnemonicBackup
 	if walletinfo.TxCount > 0 {
 		status.HasTransactions = true

--- a/bridge/offers.go
+++ b/bridge/offers.go
@@ -3,8 +3,8 @@ package bridge
 import (
 	"time"
 
-	"github.com/duality-solutions/web-bridge/internal/util"
 	"github.com/duality-solutions/web-bridge/blockchain/rpc/dynamic"
+	"github.com/duality-solutions/web-bridge/internal/util"
 	"github.com/pion/webrtc/v2"
 )
 
@@ -132,10 +132,7 @@ func SendOffer(link *Bridge) bool {
 func sendOnlineNotification(link *Bridge, wait time.Duration) {
 	select {
 	case <-time.After(wait):
-		notification := OnlineNotification{
-			StartTime: startEpoch,
-			EndTime:   endEpoch,
-		}
+		notification := notificationInfo.getCurrentNotification()
 		encoded, err := util.EncodeObject(notification)
 		if err != nil {
 			util.Error.Println("DisconnectedLinks EncodeObject error", link.LinkAccount, err)
@@ -150,8 +147,7 @@ func sendOnlineNotification(link *Bridge, wait time.Duration) {
 // DisconnectedLinks reinitializes the WebRTC link bridge struct
 func DisconnectedLinks(stopchan *chan struct{}) bool {
 	bridges := bridgeControler.Unconnected()
-	endEpoch = 0
-	startEpoch = time.Now().Unix()
+	notificationInfo.updateDates(time.Now().Unix(), 0)
 	for _, link := range bridges {
 		if link.State() == StateInit && link.RTCState() == "closed" {
 			link.SetRTCState("")

--- a/bridge/online.go
+++ b/bridge/online.go
@@ -1,0 +1,46 @@
+package bridge
+
+import "sync"
+
+// OnlineNotification stores start and end WebBridge session time
+type OnlineNotification struct {
+	StartTime int64 `json:"start_time"`
+	EndTime   int64 `json:"end_time"`
+	mut       *sync.RWMutex
+}
+
+func newOnlineNotification() OnlineNotification {
+	on := OnlineNotification{
+		StartTime: 0,
+		EndTime:   0,
+	}
+	on.mut = new(sync.RWMutex)
+	return on
+}
+
+func (on *OnlineNotification) updateDates(start int64, end int64) {
+	on.mut.Lock()
+	defer on.mut.Unlock()
+	on.StartTime = start
+	on.EndTime = end
+}
+
+// GetStartTime returns the online notification last epoch start time
+func (on *OnlineNotification) GetStartTime() int64 {
+	on.mut.RLock()
+	defer on.mut.RUnlock()
+	return on.StartTime
+}
+
+// GetEndTime returns the online notification last epoch end time
+func (on *OnlineNotification) GetEndTime() int64 {
+	on.mut.RLock()
+	defer on.mut.RUnlock()
+	return on.EndTime
+}
+
+func (on *OnlineNotification) getCurrentNotification() OnlineNotification {
+	on.mut.RLock()
+	defer on.mut.RUnlock()
+	return *on
+}

--- a/bridge/rtc.go
+++ b/bridge/rtc.go
@@ -14,41 +14,14 @@ Offer Peer (EstablishRTC)					 Answer Peer (WaitForRTC)
 */
 
 import (
-	"sync"
 	"time"
 
 	"github.com/duality-solutions/web-bridge/internal/util"
 	"github.com/pion/webrtc/v2"
 )
 
-type keepAlive struct {
-	alive bool
-	*sync.RWMutex
-}
-
-func newKeepAlive() keepAlive {
-	ka := keepAlive{
-		alive: false,
-	}
-	ka.RWMutex = new(sync.RWMutex)
-	return ka
-}
-
-func (ka *keepAlive) UpdateAlive(a bool) {
-	ka.Lock()
-	defer ka.Unlock()
-	ka.alive = a
-}
-
-func (ka *keepAlive) Alive() bool {
-	ka.RLock()
-	defer ka.RUnlock()
-	return ka.alive
-}
-
 // EstablishRTC tries to establish a real time connection (RTC) bridge with the link
 func EstablishRTC(link *Bridge) {
-	keepAlive := newKeepAlive()
 	stopchan := make(chan struct{})
 	if link.PeerConnection() == nil {
 		util.Info.Println("EstablishRTC PeerConnection nil for", link.LinkAccount)
@@ -61,18 +34,12 @@ func EstablishRTC(link *Bridge) {
 		link.SetOnStateChangeEpoch(time.Now().Unix())
 		util.Info.Printf("EstablishRTC ICE Connection State has changed for %s: %s\n", link.LinkParticipants(), connectionState.String())
 		if link.RTCState() == "checking" && connectionState.String() == "failed" {
-			//keepAlive = false
-			keepAlive.UpdateAlive(false)
 			close(stopchan)
-			return
 		}
 		link.SetRTCState(connectionState.String())
 		if connectionState.String() == "disconnected" {
 			link.ShutdownHTTPProxyServers()
-			//keepAlive = false
-			keepAlive.UpdateAlive(false)
 			close(stopchan)
-			return
 		}
 	})
 
@@ -86,24 +53,26 @@ func EstablishRTC(link *Bridge) {
 			raw, err := link.DataChannel().Detach()
 			if err != nil {
 				util.Error.Println("EstablishRTC link DataChannel OnOpen error", err)
-				//keepAlive = false
-				keepAlive.UpdateAlive(false)
 				close(stopchan)
-				return
+			} else {
+				go link.StartBridgeNetwork(raw, raw)
 			}
-			go link.StartBridgeNetwork(raw, raw)
 		} else {
-			util.Error.Println("EstablishRTC link.DataChannel().OnOpen nil DataChannel")
+			util.Error.Println("EstablishRTC link.DataChannel().OnOpen nil DataChannel. Stopping")
+			close(stopchan)
 		}
 	})
 
 	link.DataChannel().OnError(func(err error) {
-		link.SetOnErrorEpoch(time.Now().Unix())
-		util.Error.Printf("EstablishRTC DataChannel OnError '%s': '%s'\n", link.DataChannel().Label(), err.Error())
-		//keepAlive = false
-		keepAlive.UpdateAlive(false)
-		close(stopchan)
-		return
+		if link.DataChannel() != nil {
+			link.SetOnErrorEpoch(time.Now().Unix())
+			util.Error.Printf("EstablishRTC DataChannel OnError '%s': '%s'\n", link.DataChannel().Label(), err.Error())
+			close(stopchan)
+		} else {
+			link.SetOnErrorEpoch(time.Now().Unix())
+			util.Error.Printf("EstablishRTC DataChannel.OnError DataChannel is nil\n")
+			close(stopchan)
+		}
 	})
 
 	// Set the local SessionDescription
@@ -119,12 +88,9 @@ func EstablishRTC(link *Bridge) {
 	}
 	util.Info.Println("EstablishRTC SetRemoteDescription", link.LinkAccount)
 
-	for keepAlive.Alive() {
+	for true {
 		select {
 		default:
-			if !keepAlive.Alive() {
-				break
-			}
 		case <-stopchan:
 			break
 		}
@@ -151,7 +117,6 @@ func EstablishRTC(link *Bridge) {
 // WaitForRTC waits for a real time connection (RTC) bridge with the link
 // TODO: add timeout
 func WaitForRTC(link *Bridge) {
-	keepAlive := newKeepAlive()
 	stopchan := make(chan struct{})
 	if link.PeerConnection() == nil {
 		util.Error.Println("WaitForRTC PeerConnection nil for", link.LinkAccount)
@@ -165,18 +130,12 @@ func WaitForRTC(link *Bridge) {
 		link.SetOnStateChangeEpoch(time.Now().Unix())
 		util.Info.Printf("WaitForRTC ICE Connection State has changed for %s: %s\n", link.LinkParticipants(), connectionState.String())
 		if link.RTCState() == "checking" && connectionState.String() == "failed" {
-			//keepAlive = false
-			keepAlive.UpdateAlive(false)
 			close(stopchan)
-			return
 		}
 		link.SetRTCState(connectionState.String())
 		if connectionState.String() == "disconnected" {
 			link.ShutdownHTTPProxyServers()
-			//keepAlive = false
-			keepAlive.UpdateAlive(false)
 			close(stopchan)
-			return
 		}
 	})
 
@@ -186,28 +145,34 @@ func WaitForRTC(link *Bridge) {
 		util.Info.Printf("WaitForRTC New DataChannel %s %d\n", link.DataChannel().Label(), link.DataChannel().ID())
 		// Register channel opening handling
 		link.DataChannel().OnOpen(func() {
-			link.SetOnOpenEpoch(time.Now().Unix())
-			link.SetState(StateOpenConnection)
-			util.Info.Printf("WaitForRTC Data channel '%s'-'%d' open.\n", link.DataChannel().Label(), link.DataChannel().ID())
-			// Detach the data channel
-			raw, err := link.DataChannel().Detach()
-			if err != nil {
-				util.Error.Println("WaitForRTC link DataChannel OnOpen error", err)
-				//keepAlive = false
-				keepAlive.UpdateAlive(false)
+			if link.DataChannel() != nil {
+				link.SetOnOpenEpoch(time.Now().Unix())
+				link.SetState(StateOpenConnection)
+				util.Info.Printf("WaitForRTC Data channel '%s'-'%d' open.\n", link.DataChannel().Label(), link.DataChannel().ID())
+				// Detach the data channel
+				raw, err := link.DataChannel().Detach()
+				if err != nil {
+					util.Error.Println("WaitForRTC link DataChannel OnOpen error", err)
+					close(stopchan)
+				} else {
+					go link.StartBridgeNetwork(raw, raw)
+				}
+			} else {
+				util.Error.Println("WaitForRTC link.DataChannel().OnOpen nil DataChannel. Stopping")
 				close(stopchan)
-				return
 			}
-			go link.StartBridgeNetwork(raw, raw)
 		})
 
 		link.DataChannel().OnError(func(err error) {
-			link.SetOnErrorEpoch(time.Now().Unix())
-			util.Error.Printf("WaitForRTC DataChannel OnError '%s': '%s'\n", link.DataChannel().Label(), err.Error())
-			//keepAlive = false
-			keepAlive.UpdateAlive(false)
-			close(stopchan)
-			return
+			if link.DataChannel() != nil {
+				link.SetOnErrorEpoch(time.Now().Unix())
+				util.Error.Printf("WaitForRTC DataChannel OnError '%s': '%s'\n", link.DataChannel().Label(), err.Error())
+				close(stopchan)
+			} else {
+				link.SetOnErrorEpoch(time.Now().Unix())
+				util.Error.Printf("WaitForRTC DataChannel.OnError DataChannel is nil\n")
+				close(stopchan)
+			}
 		})
 	})
 
@@ -215,17 +180,13 @@ func WaitForRTC(link *Bridge) {
 	err := link.PeerConnection().SetLocalDescription(link.Answer())
 	if err != nil {
 		util.Error.Println("WaitForRTC SetLocalDescription error ", link.LinkParticipants(), err)
-		//keepAlive = false
-		keepAlive.UpdateAlive(false)
+		close(stopchan)
 	}
 	util.Info.Println("WaitForRTC SetLocalDescription", link.LinkAccount)
 
-	for keepAlive.Alive() {
+	for true {
 		select {
 		default:
-			if !keepAlive.Alive() {
-				break
-			}
 		case <-stopchan:
 			break
 		}

--- a/bridge/rtc.go
+++ b/bridge/rtc.go
@@ -78,19 +78,23 @@ func EstablishRTC(link *Bridge) {
 
 	// Register channel opening handling
 	link.DataChannel().OnOpen(func() {
-		link.SetOnOpenEpoch(time.Now().Unix())
-		link.SetState(StateOpenConnection)
-		util.Info.Printf("EstablishRTC Data channel '%s'-'%d' open.\n", link.DataChannel().Label(), link.DataChannel().ID())
-		// Detach the data channel
-		raw, err := link.DataChannel().Detach()
-		if err != nil {
-			util.Error.Println("EstablishRTC link DataChannel OnOpen error", err)
-			//keepAlive = false
-			keepAlive.UpdateAlive(false)
-			close(stopchan)
-			return
+		if link.DataChannel() != nil {
+			link.SetOnOpenEpoch(time.Now().Unix())
+			link.SetState(StateOpenConnection)
+			util.Info.Printf("EstablishRTC Data channel '%s'-'%d' open.\n", link.DataChannel().Label(), link.DataChannel().ID())
+			// Detach the data channel
+			raw, err := link.DataChannel().Detach()
+			if err != nil {
+				util.Error.Println("EstablishRTC link DataChannel OnOpen error", err)
+				//keepAlive = false
+				keepAlive.UpdateAlive(false)
+				close(stopchan)
+				return
+			}
+			go link.StartBridgeNetwork(raw, raw)
+		} else {
+			util.Error.Println("EstablishRTC link.DataChannel().OnOpen nil DataChannel")
 		}
-		go link.StartBridgeNetwork(raw, raw)
 	})
 
 	link.DataChannel().OnError(func(err error) {

--- a/internal/webbridge/command.go
+++ b/internal/webbridge/command.go
@@ -36,15 +36,13 @@ func appCommandLoop(stopBridges *chan struct{}, acc *[]dynamic.Account, al *dyna
 		for {
 			select {
 			default:
-
 				if !unlocked {
 					errUnlock := d.UnlockWallet("")
 					if errUnlock != nil {
 						util.Info.Println("Wallet locked so links are unavailable. Use the unlock command to start your link bridges.")
 					} else {
 						unlocked = true
-						util.Info.Println("Starting bridges.")
-						go bridge.StartBridges(stopBridges, config, *d, *acc, *al)
+						bridge.StartBridges(stopBridges, config, *d, *acc, *al)
 						bridgesStarted = true
 					}
 				}
@@ -94,8 +92,7 @@ func appCommandLoop(stopBridges *chan struct{}, acc *[]dynamic.Account, al *dyna
 					}
 				}
 				if unlocked && !bridgesStarted && acc != nil && al != nil {
-					util.Info.Println("Starting bridges.")
-					go bridge.StartBridges(stopBridges, config, *d, *acc, *al)
+					bridge.StartBridges(stopBridges, config, *d, *acc, *al)
 					bridgesStarted = true
 				}
 			case <-*shutdown.Close:

--- a/internal/webbridge/init.go
+++ b/internal/webbridge/init.go
@@ -172,7 +172,7 @@ func Init(version, githash string) error {
 			util.Info.Printf("Found %v links\n", len(al.Links))
 		}
 
-		go appCommandLoop(&stopBridges, acc, al, &shutdown, dynamicd, status, sync)
+		appCommandLoop(&stopBridges, acc, al, &shutdown, dynamicd, status, sync)
 
 		for {
 			select {

--- a/tests/race/maptest.go
+++ b/tests/race/maptest.go
@@ -1,0 +1,77 @@
+package main
+
+// one goroutine is the main
+// goroutine that comes by default
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"sync"
+	"time"
+)
+
+type message struct {
+	counter int
+}
+
+type messages struct {
+	mapMessages map[string]chan *message
+	mapMess     map[string]*message
+	*sync.RWMutex
+}
+
+func (m *messages) updateMessageMap(id string, message *message) {
+	m.Lock()
+	defer m.Unlock()
+	m.mapMessages[id] <- message
+}
+
+func (m *messages) updateMessMap(id string, message *message) {
+	m.Lock()
+	defer m.Unlock()
+	m.mapMess[id] = message
+}
+
+func newMessages() *messages {
+	m := messages{}
+	m.mapMessages = make(map[string]chan *message)
+	m.mapMess = make(map[string]*message)
+	m.RWMutex = new(sync.RWMutex)
+	return &m
+}
+
+var wgIns sync.WaitGroup
+
+func main() {
+	wgIns.Add(6)
+	var msgs = newMessages()
+	s1 := rand.NewSource(time.Now().UnixNano())
+	r1 := rand.New(s1)
+	msg := message{
+		counter: r1.Intn(100),
+	}
+	for i := 0; i < 3; i++ {
+		// goroutines are made
+		go func() {
+			for j := 0; j < 3; j++ {
+				// shared variable execution
+				msgs.mapMessages["1"] <- &msg
+				msgs.mapMess["1"] = &msg //no race
+			}
+		}()
+		wgIns.Done()
+	}
+	for i := 0; i < 3; i++ {
+		// goroutines are made
+		go func() {
+			for j := 0; j < 3; j++ {
+				// shared variable execution
+				msgs.mapMess["1"] = &msg //race
+			}
+		}()
+		wgIns.Done()
+	}
+	fmt.Println("The number of goroutines before wait =", runtime.NumGoroutine())
+	wgIns.Wait()
+	fmt.Println("The number of goroutines after wait = ", runtime.NumGoroutine())
+}


### PR DESCRIPTION
- Fix race condition when starting Gin web services …
- Fix race condition when shutting down bridges …
- Fix race condition after init wallet setup called …
- Disallow admin API access from bridge connection …
- Fix get /api/v1/overview Swagger return documentation
- Isolate race condition within readWebRTCMessageLoop …
- Add race test code with maps and channels
- Fix race condition during RTC shutdown …
- Fix race during bridge shutdown notifications …
- Check if data channel is nil before using
- Replace keep alive mutex with a channel in RTC